### PR TITLE
Register waila components along side built in components to preserve repositioning in hud editor.

### DIFF
--- a/src/main/java/toufoumaster/btwaila/BTWailaComponents.java
+++ b/src/main/java/toufoumaster/btwaila/BTWailaComponents.java
@@ -8,8 +8,9 @@ import net.minecraft.client.gui.hud.component.layout.LayoutAbsolute;
 import net.minecraft.client.gui.hud.component.layout.LayoutSnap;
 import toufoumaster.btwaila.gui.components.*;
 import turniplabs.halplibe.util.ClientStartEntrypoint;
+import toufoumaster.btwaila.interfaces.HudComponentsRegisteredEntryPoint;
 
-public class BTWailaComponents implements ClientStartEntrypoint {
+public class BTWailaComponents implements ClientStartEntrypoint, HudComponentsRegisteredEntryPoint {
     public static HudComponent BlockBaseInfoComp;
     public static HudComponent BlockBreakComp;
     public static HudComponent BlockAdvancedInfoComp;
@@ -23,6 +24,11 @@ public class BTWailaComponents implements ClientStartEntrypoint {
 
     @Override
     public void afterClientStart() {
+
+    }
+
+    @Override
+    public void afterComponentsRegistered() {
         BlockBaseInfoComp = HudComponents.register(
                 new BaseInfoComponent("wailaInfoBase",
                         new LayoutAbsolute(0.5f, 0.0f, ComponentAnchor.TOP_CENTER)));

--- a/src/main/java/toufoumaster/btwaila/interfaces/HudComponentsRegisteredEntryPoint.java
+++ b/src/main/java/toufoumaster/btwaila/interfaces/HudComponentsRegisteredEntryPoint.java
@@ -1,0 +1,5 @@
+package toufoumaster.btwaila.interfaces;
+
+public interface HudComponentsRegisteredEntryPoint {
+   void afterComponentsRegistered();
+}

--- a/src/main/java/toufoumaster/btwaila/mixin/mixins/HudComponentsMixin.java
+++ b/src/main/java/toufoumaster/btwaila/mixin/mixins/HudComponentsMixin.java
@@ -1,0 +1,16 @@
+package toufoumaster.btwaila.mixin.mixins;
+import net.fabricmc.loader.api.FabricLoader;
+import net.minecraft.client.gui.hud.component.HudComponents;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import toufoumaster.btwaila.interfaces.HudComponentsRegisteredEntryPoint;
+
+@Mixin(value = HudComponents.class, remap = false)
+public class HudComponentsMixin {
+    @Inject(method = "<clinit>", at = @At(value = "TAIL"))
+    private static void init(CallbackInfo ci) {
+        FabricLoader.getInstance().getEntrypoints("afterComponentsRegistered", HudComponentsRegisteredEntryPoint.class).forEach(HudComponentsRegisteredEntryPoint::afterComponentsRegistered);
+    }
+}

--- a/src/main/resources/btwaila.mixins.json
+++ b/src/main/resources/btwaila.mixins.json
@@ -11,6 +11,7 @@
     "ScreenPauseMixin",
     "HudIngameMixin",
     "PacketHandlerClientMixin",
+    "HudComponentsMixin",
     "accessors.IPlayerControllerAccessor"
   ],
   "server": [

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -34,6 +34,9 @@
       "toufoumaster.btwaila.BTWailaComponents",
       "toufoumaster.btwaila.BTWailaClient"
     ],
+    "afterComponentsRegistered": [
+      "toufoumaster.btwaila.BTWailaComponents"
+    ],
     "btwaila": [
       "toufoumaster.btwaila.entryplugins.waila.BTWailaPlugin"
     ],


### PR DESCRIPTION
Added a mixin for injecting at the registration of built in hud components and implemented with new entry point interface. All so the position of your hud is saved by BTA and you can use the reset button.