### PR TITLE
UUIDHelper improvements

### DIFF
--- a/src/main/java/toufoumaster/btwaila/gui/components/AdvancedInfoComponent.java
+++ b/src/main/java/toufoumaster/btwaila/gui/components/AdvancedInfoComponent.java
@@ -7,7 +7,6 @@ import net.minecraft.client.gui.ScreenHudDesigner;
 import net.minecraft.client.gui.hud.HudIngame;
 import net.minecraft.client.gui.hud.component.ComponentAnchor;
 import net.minecraft.client.gui.hud.component.layout.Layout;
-import net.minecraft.core.Global;
 import net.minecraft.core.block.BlockLogicChest;
 import net.minecraft.core.block.entity.TileEntity;
 import net.minecraft.core.block.entity.TileEntityChest;
@@ -112,11 +111,11 @@ public class AdvancedInfoComponent extends WailaTextComponent {
         if (tileEntity != null && tileEntity.worldObj != null) {
             boolean askTileEntity = !(BTWaila.excludeContinuousTileEntityData.get(tileEntity.getClass()) != null ? BTWaila.excludeContinuousTileEntityData.get(tileEntity.getClass()) : false);
             if (tileEntity.worldObj == null) return;
-            if (!Global.isServer && BTWaila.canUseAdvancedTooltips && askTileEntity) {
+            if (minecraft.thePlayer instanceof PlayerLocalMultiplayer && BTWaila.canUseAdvancedTooltips && askTileEntity) {
                 PlayerLocalMultiplayer playerMP = (PlayerLocalMultiplayer) minecraft.thePlayer;
                 playerMP.sendQueue.addToSendQueue(new PacketRequestTileEntityData(tileEntity.x, tileEntity.y, tileEntity.z));
                 if (tileEntity instanceof TileEntityChest){
-                    requestOtherHalfOfChest(playerMP.world,tileEntity.x, tileEntity.y, tileEntity.z, playerMP);
+                    requestOtherHalfOfChest(playerMP.world, tileEntity.x, tileEntity.y, tileEntity.z, playerMP);
                 }
             }
             for (TileTooltip<?> tooltip : TooltipRegistry.tileTooltips) {

--- a/src/main/java/toufoumaster/btwaila/mixin/mixins/PacketHandlerClientMixin.java
+++ b/src/main/java/toufoumaster/btwaila/mixin/mixins/PacketHandlerClientMixin.java
@@ -3,6 +3,7 @@ package toufoumaster.btwaila.mixin.mixins;
 import net.minecraft.client.net.handler.PacketHandlerClient;
 import net.minecraft.core.entity.Entity;
 import net.minecraft.core.entity.Mob;
+import net.minecraft.core.net.packet.PacketAddPlayer;
 import net.minecraft.core.net.packet.PacketCustomPayload;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -11,6 +12,7 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import toufoumaster.btwaila.mixin.interfaces.IPacketHandlerClient;
 import toufoumaster.btwaila.network.packet.PacketEntityData;
+import toufoumaster.btwaila.util.UUIDHelper;
 import toufoumaster.btwaila.util.VersionHelper;
 
 @Mixin(value = PacketHandlerClient.class, remap = false)
@@ -35,5 +37,10 @@ public abstract class PacketHandlerClientMixin implements IPacketHandlerClient {
             VersionHelper.handlePacket(packet);
             ci.cancel();
         }
+    }
+
+    @Inject(method = "handleNamedEntitySpawn", at = @At("TAIL"))
+    public void mapUUIDToUsername(PacketAddPlayer addPlayerPacket, CallbackInfo ci) {
+        UUIDHelper.addMapping(addPlayerPacket.uuid, addPlayerPacket.name);
     }
 }

--- a/src/main/java/toufoumaster/btwaila/tooltips/TileTooltip.java
+++ b/src/main/java/toufoumaster/btwaila/tooltips/TileTooltip.java
@@ -3,7 +3,8 @@ package toufoumaster.btwaila.tooltips;
 import net.minecraft.core.block.entity.TileEntity;
 import toufoumaster.btwaila.gui.components.AdvancedInfoComponent;
 
-public abstract class TileTooltip<T> extends Tooltip<T>{
+public abstract class TileTooltip<T> extends Tooltip<T> {
+    protected static final String KEY_TILE_ENTITY_OWNER = "btwaila.tooltip.tile_entity.owner";
     public void _drawAdvancedTooltip(TileEntity tileEntity, AdvancedInfoComponent advancedInfoComponent){
         drawAdvancedTooltip((T) tileEntity, advancedInfoComponent);
     }

--- a/src/main/java/toufoumaster/btwaila/tooltips/block/FlagTooltip.java
+++ b/src/main/java/toufoumaster/btwaila/tooltips/block/FlagTooltip.java
@@ -3,15 +3,12 @@ package toufoumaster.btwaila.tooltips.block;
 import net.minecraft.client.render.item.model.ItemModel;
 import net.minecraft.client.render.item.model.ItemModelDispatcher;
 import net.minecraft.client.render.tessellator.Tessellator;
-import net.minecraft.core.block.Block;
 import net.minecraft.core.block.Blocks;
 import net.minecraft.core.block.entity.TileEntityFlag;
-import net.minecraft.core.item.Item;
 import net.minecraft.core.item.ItemStack;
 import net.minecraft.core.item.Items;
 import org.lwjgl.opengl.GL11;
 import toufoumaster.btwaila.demo.DemoEntry;
-import toufoumaster.btwaila.demo.DemoManager;
 import toufoumaster.btwaila.gui.components.AdvancedInfoComponent;
 import toufoumaster.btwaila.tooltips.TileTooltip;
 import toufoumaster.btwaila.util.UUIDHelper;
@@ -30,7 +27,11 @@ public class FlagTooltip extends TileTooltip<TileEntityFlag> {
         ItemStack color1 = flag.items[0];
         ItemStack color2 = flag.items[1];
         ItemStack color3 = flag.items[2];
-        advancedInfoComponent.drawStringWithShadow(translator.translateKey("btwaila.tooltip.flag.owner").replace("{name}", flag.owner == null ? translator.translateKey("btwaila.tooltip.flag.owner.none") : String.valueOf(UUIDHelper.getNameFromUUID(flag.owner))), 0);
+
+        String username = UUIDHelper.getNameI18nFromUUID(flag.owner, flag.worldObj);
+        String ownerStr = translator.translateKey(TileTooltip.KEY_TILE_ENTITY_OWNER);
+        advancedInfoComponent.drawStringWithShadow(String.format("%s: %s", ownerStr, username), 0);
+
         advancedInfoComponent.addOffY(2);
         renderStringAndStack(advancedInfoComponent,translator.translateKey("btwaila.tooltip.flag.color").replace("{id}", "1") + "    " +  ((color1 != null) ? translator.translateNameKey(color1.getItemKey()) : translator.translateKey("btwaila.tooltip.flag.empty")), 0, color1);
         renderStringAndStack(advancedInfoComponent,translator.translateKey("btwaila.tooltip.flag.color").replace("{id}", "2") + "    " +  ((color2 != null) ? translator.translateNameKey(color2.getItemKey()) : translator.translateKey("btwaila.tooltip.flag.empty")), 0, color2);

--- a/src/main/java/toufoumaster/btwaila/tooltips/block/SignTooltip.java
+++ b/src/main/java/toufoumaster/btwaila/tooltips/block/SignTooltip.java
@@ -19,7 +19,10 @@ public class SignTooltip extends TileTooltip<TileEntitySign> {
     @Override
     public void drawAdvancedTooltip(TileEntitySign interfaceObject, AdvancedInfoComponent advancedInfoComponent) {
         UUID owner = ((TileEntitySignAccessor)interfaceObject).getOwner();
-        String text = translator.translateKey("btwaila.tooltip.sign.owner").replace("{id}", owner == null ? translator.translateKey("btwaila.tooltip.sign.owner.none") : String.valueOf(UUIDHelper.getNameFromUUID(owner)));
-        advancedInfoComponent.drawStringWithShadow(text, 0);
+
+        String username = UUIDHelper.getNameI18nFromUUID(owner, interfaceObject.worldObj);
+        String ownerStr = translator.translateKey(TileTooltip.KEY_TILE_ENTITY_OWNER);
+
+        advancedInfoComponent.drawStringWithShadow(String.format("%s: %s", ownerStr, username), 0);
     }
 }

--- a/src/main/java/toufoumaster/btwaila/util/UUIDHelper.java
+++ b/src/main/java/toufoumaster/btwaila/util/UUIDHelper.java
@@ -17,7 +17,7 @@ import java.util.UUID;
 public class UUIDHelper {
     private static final String MOJANG_API_URL = "https://sessionserver.mojang.com/session/minecraft/profile/";
     private static final JsonParser JSON_PARSER = new JsonParser();
-    private static final Map<@NotNull UUID, @Nullable String> UIID_TO_NAME_MAP = new HashMap<>();
+    private static final Map<@NotNull UUID, @NotNull String> UIID_TO_NAME_MAP = new HashMap<>();
     private static final UUID EMPTY_UUID = new UUID(0, 0);
     private static final String KEY_UNKNOWN_USER = "btwaila.tooltip.username.unknown";
     private static final String KEY_NONE_USER = "btwaila.tooltip.username.none";
@@ -62,9 +62,11 @@ public class UUIDHelper {
         // Null UUID means there's no owner
         if (uuid == null || EMPTY_UUID.equals(uuid)) return null;
 
-        // 1. Try fetching from map first
-        String name = UIID_TO_NAME_MAP.getOrDefault(uuid, "");
-        if (name == null || !name.isEmpty()) return name;
+        // 1. Try fetching from map first, this will either return
+        //    the username or an empty string if a fetch failed
+        //    (or null if it hasn't been mapped)
+        String name = UIID_TO_NAME_MAP.get(uuid);
+        if (name != null) return name;
 
         // 2. Try looking for "online" players with the given UUID (if the world isn't null)
         Player player;

--- a/src/main/java/toufoumaster/btwaila/util/UUIDHelper.java
+++ b/src/main/java/toufoumaster/btwaila/util/UUIDHelper.java
@@ -79,7 +79,7 @@ public class UUIDHelper {
         name = getUsernameFromAPI(uuid);
         UIID_TO_NAME_MAP.put(uuid, name);
 
-        return null;
+        return name;
     }
 
     public static void addMapping(@NotNull UUID uuid, @NotNull String username) {

--- a/src/main/java/toufoumaster/btwaila/util/UUIDHelper.java
+++ b/src/main/java/toufoumaster/btwaila/util/UUIDHelper.java
@@ -3,6 +3,10 @@ package toufoumaster.btwaila.util;
 import com.b100.json.JsonParser;
 import com.b100.json.element.JsonObject;
 import com.b100.utils.StringUtils;
+import net.minecraft.core.entity.player.Player;
+import net.minecraft.core.lang.I18n;
+import net.minecraft.core.world.World;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.HashMap;
@@ -11,44 +15,87 @@ import java.util.UUID;
 
 // thanks melon!
 public class UUIDHelper {
+    private static final String MOJANG_API_URL = "https://sessionserver.mojang.com/session/minecraft/profile/";
+    private static final JsonParser JSON_PARSER = new JsonParser();
+    private static final Map<@NotNull UUID, @Nullable String> UIID_TO_NAME_MAP = new HashMap<>();
+    private static final UUID EMPTY_UUID = new UUID(0, 0);
+    private static final String KEY_UNKNOWN_USER = "btwaila.tooltip.username.unknown";
+    private static final String KEY_NONE_USER = "btwaila.tooltip.username.none";
 
-    private static final String url = "https://sessionserver.mojang.com/session/minecraft/profile/";
-    private static final JsonParser jsonParser = new JsonParser();
-    private static final Map<UUID, String> UUIDtoNameMap = new HashMap<>();
+    private UUIDHelper() {}
 
-    public static @Nullable String getNameFromUUID(UUID uuid){
-        if (uuid == null) return null;
+    /**
+     * Returns the username of the player with the given UUID,
+     * the translation of 'btwaila.tooltip.username.unknown' if it could not be fetched,
+     * or the translation of "btwaila.tooltip.username.none" if UUID was 0 or null.
+     * @param uuid a player's UUID or null
+     * @param world the world or null
+     * @return the username or an appropriate translation of "None" or "Unknown" (see the description for specifics)
+     */
+    public static @NotNull String getNameI18nFromUUID(@Nullable UUID uuid, @Nullable World world) {
+        String username = getNameFromUUID(uuid, world);
+        I18n i18n = I18n.getInstance();
 
-        if(UUIDtoNameMap.containsKey(uuid)){
-            return UUIDtoNameMap.get(uuid);
+        if (username == null ) {
+            return i18n.translateKey(KEY_NONE_USER);
+        }else if (username.isEmpty()) {
+            return i18n.translateKey(KEY_UNKNOWN_USER);
         }
 
-        String string;
-        try{
-            string = StringUtils.getWebsiteContentAsString(url + uuid);
-        }catch (Exception e) {
-            System.err.println("Can't connect to Mojang API.");
-            e.printStackTrace();
-            UUIDtoNameMap.put(uuid, null);
-            return null;
-        }
-        if(string.isEmpty()) {
-            System.err.println("UUID [" + uuid + "] doesn't exist!");
-            UUIDtoNameMap.put(uuid, null);
-            return null;
-        }
-        String username;
-        try {
-            JsonObject contentParsed = jsonParser.parse(string);
-            username = contentParsed.getString("name");
-        }catch (Exception e) {
-            e.printStackTrace();
-            UUIDtoNameMap.put(uuid, null);
-            return null;
-        }
-
-        UUIDtoNameMap.put(uuid, username);
         return username;
+    }
+
+    /**
+     * Returns the username of the player with the given UUID,
+     * empty string if UUID could not be fetched,
+     * or null if UUID was 0 or null.
+     * <br><br>
+     * Note:
+     * Non-existent players (such as those on offline servers with usernames that have
+     * no actual account tied to them) will have a UUID of 0, and because on regular servers UUID 0
+     * is effectively invalid, it will be treated as a 'no owner' case.
+     * @param uuid a player's UUID or null
+     * @param world the world or null
+     * @return the username, an empty string, or null (see the description for specifics)
+     */
+    public static @Nullable String getNameFromUUID(@Nullable UUID uuid, @Nullable World world){
+        // Null UUID means there's no owner
+        if (uuid == null || EMPTY_UUID.equals(uuid)) return null;
+
+        // 1. Try fetching from map first
+        String name = UIID_TO_NAME_MAP.getOrDefault(uuid, "");
+        if (name == null || !name.isEmpty()) return name;
+
+        // 2. Try looking for "online" players with the given UUID (if the world isn't null)
+        Player player;
+        if (world != null && (player = world.getPlayerEntityByUUID(uuid)) != null) {
+            name = player.username;
+            UIID_TO_NAME_MAP.put(uuid, name);
+            return name;
+        }
+
+        // 3. Try getting username from Mojang API
+        // If this also fails the given UUID will map to an empty string
+        name = getUsernameFromAPI(uuid);
+        UIID_TO_NAME_MAP.put(uuid, name);
+
+        return null;
+    }
+
+    public static void addMapping(@NotNull UUID uuid, @NotNull String username) {
+        UIID_TO_NAME_MAP.put(uuid, username);
+    }
+
+    private static @NotNull String getUsernameFromAPI(@NotNull UUID uuid) {
+        try {
+            String content = StringUtils.getWebsiteContentAsString(MOJANG_API_URL + uuid);
+            JsonObject contentParsed = JSON_PARSER.parse(content);
+            String username = contentParsed.getString("name");
+            // Not sure if this can be null, but we'll check it just in case
+            return username == null ? "" : username;
+        }catch (Exception ignored) {
+            return "";
+        }
     }
 
 }

--- a/src/main/resources/lang/btwaila/en_US.lang
+++ b/src/main/resources/lang/btwaila/en_US.lang
@@ -74,8 +74,10 @@ btwaila.tooltip.boat.passenger=Passenger: {name}
 
 btwaila.tooltip.pig.passenger=Passenger: {name}
 
-btwaila.tooltip.flag.owner=Owner: {name}
-btwaila.tooltip.flag.owner.none=None
+btwaila.tooltip.tile_entity.owner=Owner
+btwaila.tooltip.username.unknown=Unknown
+btwaila.tooltip.username.none=None
+
 btwaila.tooltip.flag.color=Color {id}:
 btwaila.tooltip.flag.empty=No Item
 
@@ -98,9 +100,6 @@ btwaila.tooltip.noteblock.material.wood=Wood
 btwaila.tooltip.noteblock.material.none=None
 
 btwaila.tooltip.jukebox.disc=Disc id: {id}
-
-btwaila.tooltip.sign.owner=Owner: {id}
-btwaila.tooltip.sign.owner.none=None
 
 btwaila.tooltip.trommel.progress=Progress: §r
 


### PR DESCRIPTION
~~Fixes UUIDHelper freezing your game when looking at signs or flags if the UUID was invalid or could not be fetched.~~
> Apparently this was already fixed by https://github.com/ToufouMaster/BTWaila/pull/22, the rest should still apply

`UUIDHelper#getNameI18nFromUUID` should now be used for getting usernames if necessary, as it will return two different translated keys instead of null, based on why it couldn't get the username:
- `None` - The UUID was null or 0 (which is effectively invalid), signifies that a sign/flag has no owner
- `Unknown` - The UUID could not be matched to a username for various reasons
- Otherwise it returns the username for the given UUID

The UUID map should now also be updated when a player joins the server.

**Misc:**
- https://github.com/ToufouMaster/BTWaila/pull/25/commits/03904e370db8fed1ee2fef63bba314fe891a2949 - Fixed bad isServer check crashing the game when switching from multiplayer to singleplayer